### PR TITLE
Fix: Smaller macOS binaries (take 2)

### DIFF
--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -61,7 +61,7 @@ jobs:
             shacmd: 'sha512sum'
           - os: macosx
             runner: macos-13
-            os-cmake-args: '-DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++ -flto -ffunction-sections -fdata-sections" -DCMAKE_EXE_LINKER_FLAGS="--gc-sections" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 ${POSIX_CMAKE_ARGS} ${MACOS_CMAKE_ARGS} -DLLVM_TARGETS_TO_BUILD=X86'
+            os-cmake-args: '-DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++ -flto -ffunction-sections -fdata-sections" -DCMAKE_EXE_LINKER_FLAGS="-Wl,-dead_strip" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 ${POSIX_CMAKE_ARGS} ${MACOS_CMAKE_ARGS} -DLLVM_TARGETS_TO_BUILD=X86'
             build-args: '-j$(sysctl -n hw.ncpu)'
             bindir: '/build/bin'
             dotexe: ''


### PR DESCRIPTION
# What
Reduces the size of macOS binaries

Before:

```
./clang-tools-llvm-project-19.1.0.src-19_macosx-amd64:
total 2141512
drwxr-xr-x  2 runner docker       4096 May 23 19:49 .
drwxr-xr-x 58 runner docker       4096 May 23 19:48 ..
-rw-r--r--  1 runner docker    3603104 May 23 19:48 clang-apply-replacements-19_macosx-amd64
-rw-r--r--  1 runner docker        171 May 23 19:48 clang-apply-replacements-19_macosx-amd64.sha512sum
-rw-r--r--  1 runner docker    4446688 May 23 19:48 clang-format-19_macosx-amd64
-rw-r--r--  1 runner docker        159 May 23 19:48 clang-format-19_macosx-amd64.sha512sum
-rw-r--r--  1 runner docker   37778728 May 23 19:48 clang-query-19_macosx-amd64
-rw-r--r--  1 runner docker        158 May 23 19:48 clang-query-19_macosx-amd64.sha512sum
-rw-r--r--  1 runner docker 2147042256 May 23 19:49 clang-tidy-19_macosx-amd64
-rw-r--r--  1 runner docker        157 May 23 19:49 clang-tidy-19_macosx-amd64.sha512sum

./clang-tools-llvm-project-20.1.0.src-20_macosx-amd64:
total 2156684
drwxr-xr-x  2 runner docker       4096 May 23 19:49 .
drwxr-xr-x 58 runner docker       4096 May 23 19:48 ..
-rw-r--r--  1 runner docker    4366720 May 23 19:48 clang-apply-replacements-20_macosx-amd64
-rw-r--r--  1 runner docker        171 May 23 19:48 clang-apply-replacements-20_macosx-amd64.sha512sum
-rw-r--r--  1 runner docker    4531752 May 23 19:48 clang-format-20_macosx-amd64
-rw-r--r--  1 runner docker        159 May 23 19:48 clang-format-20_macosx-amd64.sha512sum
-rw-r--r--  1 runner docker   38634992 May 23 19:48 clang-query-20_macosx-amd64
-rw-r--r--  1 runner docker        158 May 23 19:48 clang-query-20_macosx-amd64.sha512sum
-rw-r--r--  1 runner docker 2160871896 May 23 19:49 clang-tidy-20_macosx-amd64
-rw-r--r--  1 runner docker        157 May 23 19:49 clang-tidy-20_macosx-amd64.sha512sum
```

After:

```
./clang-tools-llvm-project-19.1.0.src-19_macosx-amd64:
total 113888
drwxr-xr-x  2 runner docker     4096 May 23 20:55 .
drwxr-xr-x 59 runner docker     4096 May 23 20:54 ..
-rw-r--r--  1 runner docker  3603104 May 23 20:54 clang-apply-replacements-19_macosx-amd64
-rw-r--r--  1 runner docker      171 May 23 20:54 clang-apply-replacements-19_macosx-amd64.sha512sum
-rw-r--r--  1 runner docker  4446688 May 23 20:54 clang-format-19_macosx-amd64
-rw-r--r--  1 runner docker      159 May 23 20:54 clang-format-19_macosx-amd64.sha512sum
-rw-r--r--  1 runner docker 37778728 May 23 20:54 clang-query-19_macosx-amd64
-rw-r--r--  1 runner docker      158 May 23 20:54 clang-query-19_macosx-amd64.sha512sum
-rw-r--r--  1 runner docker 70759064 May 23 20:55 clang-tidy-19_macosx-amd64
-rw-r--r--  1 runner docker      157 May 23 20:55 clang-tidy-19_macosx-amd64.sha512sum

./clang-tools-llvm-project-20.1.0.src-20_macosx-amd64:
total 116356
drwxr-xr-x  2 runner docker     4096 May 23 20:55 .
drwxr-xr-x 59 runner docker     4096 May 23 20:54 ..
-rw-r--r--  1 runner docker  4366720 May 23 20:54 clang-apply-replacements-20_macosx-amd64
-rw-r--r--  1 runner docker      171 May 23 20:54 clang-apply-replacements-20_macosx-amd64.sha512sum
-rw-r--r--  1 runner docker  4531752 May 23 20:54 clang-format-20_macosx-amd64
-rw-r--r--  1 runner docker      159 May 23 20:54 clang-format-20_macosx-amd64.sha512sum
-rw-r--r--  1 runner docker 38634992 May 23 20:54 clang-query-20_macosx-amd64
-rw-r--r--  1 runner docker      158 May 23 20:54 clang-query-20_macosx-amd64.sha512sum
-rw-r--r--  1 runner docker 71581496 May 23 20:55 clang-tidy-20_macosx-amd64
-rw-r--r--  1 runner docker      157 May 23 20:55 clang-tidy-20_macosx-amd64.sha512sum
```

# How
Using gcc flags as recommended here: https://github.com/muttleyxd/clang-tools-static-binaries/issues/55#issuecomment-2583499381

Tests pass, binaries seem to be working

Closes #55 
Closes #20 
