### PR TITLE
Updates upload-release-action to fix API usage issue

### DIFF
--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -332,7 +332,7 @@ jobs:
       - name: draft release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: svenstaro/upload-release-action@v2.10.0
+        uses: svenstaro/upload-release-action@2.10.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           draft: true


### PR DESCRIPTION
Updates to upload-release-action 2.10.0 which allows disabling the duplicates check for reduced API usage.

Closes #72 