### PR TITLE
Fixing cmake minimum issues

### DIFF
--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -15,7 +15,7 @@ jobs:
       cancel-in-progress: true
     strategy:
       matrix:
-        clang-version: [ 18, 19, 20 ]
+        clang-version: [ 15, 16, 17, 18, 19, 20 ]
         os: [ linux, macosx, macos-arm, windows ]
         include:
           # Temporarily disabled versions for testing
@@ -48,12 +48,12 @@ jobs:
           #   release: llvm-project-13.0.0.src
           # - clang-version: 14
           #   release: llvm-project-14.0.0.src
-          # - clang-version: 15
-          #   release: llvm-project-15.0.2.src
-          # - clang-version: 16
-          #   release: llvm-project-16.0.3.src
-          # - clang-version: 17
-          #   release: llvm-project-17.0.4.src
+          - clang-version: 15
+            release: llvm-project-15.0.2.src
+          - clang-version: 16
+            release: llvm-project-16.0.3.src
+          - clang-version: 17
+            release: llvm-project-17.0.4.src
           - clang-version: 18
             release: llvm-project-18.1.8.src
           - clang-version: 19
@@ -98,12 +98,12 @@ jobs:
             extra-tar-args: '--exclude=${RELEASE}/clang/test/Driver/Inputs/* --exclude=${RELEASE}/libcxx/test/std/input.output/filesystems/Inputs/static_test_env/* --exclude=${RELEASE}/libclc/amdgcn-mesa3d'
             extra-tar-args-cfe: '--exclude=cfe-${version}.src/test/Driver/Inputs/*'
             arch: 'amd64'
-        # exclude:
+        exclude:
           # Clang 17 does not build on mac arm
           # See: https://github.com/llvm/llvm-project/pull/78704
           # https://github.com/llvm/llvm-project/issues/106521
-          # - clang-version: 17
-          #   os: macos-arm
+          - clang-version: 17
+            os: macos-arm
     runs-on: ${{ matrix.runner }}
     env:
       COMMON_CMAKE_ARGS: '-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"'

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -98,12 +98,12 @@ jobs:
             extra-tar-args: '--exclude=${RELEASE}/clang/test/Driver/Inputs/* --exclude=${RELEASE}/libcxx/test/std/input.output/filesystems/Inputs/static_test_env/* --exclude=${RELEASE}/libclc/amdgcn-mesa3d'
             extra-tar-args-cfe: '--exclude=cfe-${version}.src/test/Driver/Inputs/*'
             arch: 'amd64'
-        exclude:
+        # exclude:
           # Clang 17 does not build on mac arm
           # See: https://github.com/llvm/llvm-project/pull/78704
           # https://github.com/llvm/llvm-project/issues/106521
-          - clang-version: 17
-            os: macos-arm
+          # - clang-version: 17
+          #   os: macos-arm
     runs-on: ${{ matrix.runner }}
     env:
       COMMON_CMAKE_ARGS: '-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"'

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -15,7 +15,7 @@ jobs:
       cancel-in-progress: true
     strategy:
       matrix:
-        clang-version: [ 15, 16, 17, 18, 19, 20 ]
+        clang-version: [ 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
         os: [ linux, macosx, macos-arm, windows ]
         include:
           # Temporarily disabled versions for testing
@@ -40,14 +40,14 @@ jobs:
           #   extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
           # - clang-version: 11
           #   release: llvm-project-11.1.0.src
-          # - clang-version: 12
-          #   release: llvm-project-12.0.0.src
-          # - clang-version: 12.0.1
-          #   release: llvm-project-12.0.1.src
-          # - clang-version: 13
-          #   release: llvm-project-13.0.0.src
-          # - clang-version: 14
-          #   release: llvm-project-14.0.0.src
+          - clang-version: 12
+            release: llvm-project-12.0.0.src
+          - clang-version: 12.0.1
+            release: llvm-project-12.0.1.src
+          - clang-version: 13
+            release: llvm-project-13.0.0.src
+          - clang-version: 14
+            release: llvm-project-14.0.0.src
           - clang-version: 15
             release: llvm-project-15.0.2.src
           - clang-version: 16

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -15,7 +15,7 @@ jobs:
       cancel-in-progress: true
     strategy:
       matrix:
-        clang-version: [ 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
+        clang-version: [ 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
         os: [ linux, macosx, macos-arm, windows ]
         include:
           # Temporarily disabled versions for testing
@@ -36,9 +36,10 @@ jobs:
           #   release: llvm-project-9.0.1
           #   extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
           # NOTE: Version 9 fails with CMake 4 compatibility issues
-          - clang-version: 10
-            release: llvm-project-10.0.1
-            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          # - clang-version: 10
+          #   release: llvm-project-10.0.1
+          #   extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          # NOTE: Version 10 also fails with CMake 4 compatibility issues
           - clang-version: 11
             release: llvm-project-11.1.0.src
           - clang-version: 12

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -15,7 +15,7 @@ jobs:
       cancel-in-progress: true
     strategy:
       matrix:
-        clang-version: [ 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
+        clang-version: [ 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
         os: [ linux, macosx, macos-arm, windows ]
         include:
           # Temporarily disabled versions for testing
@@ -32,9 +32,10 @@ jobs:
           # - clang-version: 8
           #   release: llvm-project-8.0.1
           #   extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
-          - clang-version: 9
-            release: llvm-project-9.0.1
-            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          # - clang-version: 9
+          #   release: llvm-project-9.0.1
+          #   extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          # NOTE: Version 9 fails with CMake 4 compatibility issues
           - clang-version: 10
             release: llvm-project-10.0.1
             extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -15,7 +15,7 @@ jobs:
       cancel-in-progress: true
     strategy:
       matrix:
-        clang-version: [ 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
+        clang-version: [ 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
         os: [ linux, macosx, macos-arm, windows ]
         include:
           # Temporarily disabled versions for testing
@@ -40,8 +40,9 @@ jobs:
           #   release: llvm-project-10.0.1
           #   extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
           # NOTE: Version 10 also fails with CMake 4 compatibility issues
-          - clang-version: 11
-            release: llvm-project-11.1.0.src
+          # - clang-version: 11
+          #   release: llvm-project-11.1.0.src
+          # NOTE: Version 11 also fails with CMake 4 compatibility issues
           - clang-version: 12
             release: llvm-project-12.0.0.src
           - clang-version: 12.0.1

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -15,44 +15,45 @@ jobs:
       cancel-in-progress: true
     strategy:
       matrix:
-        clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
+        clang-version: [ 18, 19, 20 ]
         os: [ linux, macosx, macos-arm, windows ]
         include:
-          - clang-version: 3.9
-            release: llvm-project-3.9.1
-          - clang-version: 4
-            release: llvm-project-4.0.1
-          - clang-version: 5
-            release: llvm-project-5.0.2
-          - clang-version: 6
-            release: llvm-project-6.0.1
-          - clang-version: 7
-            release: llvm-project-7.1.0
-          - clang-version: 8
-            release: llvm-project-8.0.1
-            extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
-          - clang-version: 9
-            release: llvm-project-9.0.1
-            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          - clang-version: 10
-            release: llvm-project-10.0.1
-            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          - clang-version: 11
-            release: llvm-project-11.1.0.src
-          - clang-version: 12
-            release: llvm-project-12.0.0.src
-          - clang-version: 12.0.1
-            release: llvm-project-12.0.1.src
-          - clang-version: 13
-            release: llvm-project-13.0.0.src
-          - clang-version: 14
-            release: llvm-project-14.0.0.src
-          - clang-version: 15
-            release: llvm-project-15.0.2.src
-          - clang-version: 16
-            release: llvm-project-16.0.3.src
-          - clang-version: 17
-            release: llvm-project-17.0.4.src
+          # Temporarily disabled versions for testing
+          # - clang-version: 3.9
+          #   release: llvm-project-3.9.1
+          # - clang-version: 4
+          #   release: llvm-project-4.0.1
+          # - clang-version: 5
+          #   release: llvm-project-5.0.2
+          # - clang-version: 6
+          #   release: llvm-project-6.0.1
+          # - clang-version: 7
+          #   release: llvm-project-7.1.0
+          # - clang-version: 8
+          #   release: llvm-project-8.0.1
+          #   extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
+          # - clang-version: 9
+          #   release: llvm-project-9.0.1
+          #   extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          # - clang-version: 10
+          #   release: llvm-project-10.0.1
+          #   extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          # - clang-version: 11
+          #   release: llvm-project-11.1.0.src
+          # - clang-version: 12
+          #   release: llvm-project-12.0.0.src
+          # - clang-version: 12.0.1
+          #   release: llvm-project-12.0.1.src
+          # - clang-version: 13
+          #   release: llvm-project-13.0.0.src
+          # - clang-version: 14
+          #   release: llvm-project-14.0.0.src
+          # - clang-version: 15
+          #   release: llvm-project-15.0.2.src
+          # - clang-version: 16
+          #   release: llvm-project-16.0.3.src
+          # - clang-version: 17
+          #   release: llvm-project-17.0.4.src
           - clang-version: 18
             release: llvm-project-18.1.8.src
           - clang-version: 19

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -15,7 +15,7 @@ jobs:
       cancel-in-progress: true
     strategy:
       matrix:
-        clang-version: [ 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
+        clang-version: [ 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
         os: [ linux, macosx, macos-arm, windows ]
         include:
           # Temporarily disabled versions for testing
@@ -32,14 +32,14 @@ jobs:
           # - clang-version: 8
           #   release: llvm-project-8.0.1
           #   extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
-          # - clang-version: 9
-          #   release: llvm-project-9.0.1
-          #   extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          # - clang-version: 10
-          #   release: llvm-project-10.0.1
-          #   extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          # - clang-version: 11
-          #   release: llvm-project-11.1.0.src
+          - clang-version: 9
+            release: llvm-project-9.0.1
+            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          - clang-version: 10
+            release: llvm-project-10.0.1
+            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          - clang-version: 11
+            release: llvm-project-11.1.0.src
           - clang-version: 12
             release: llvm-project-12.0.0.src
           - clang-version: 12.0.1


### PR DESCRIPTION
# What
Getting the repo up and running with the latest CMake.

# How
This disables old clang-tools versions which no longer build on the VMs provided by GitHub.

# Why
* Building legacy versions of clang-tools requires a legacy build system
* Maintaining a legacy build system here on GitHub Actions is a project I cannot prioritize

Closes #90